### PR TITLE
Add parser events and listener

### DIFF
--- a/peek/completer.py
+++ b/peek/completer.py
@@ -12,7 +12,7 @@ from peek.common import PeekToken
 from peek.completions import PayloadKeyCompletion
 from peek.es_api_spec.spec import ApiSpec
 from peek.lexers import PeekLexer, UrlPathLexer, PathPart, ParamName, Ampersand, QuestionMark, Slash, HttpMethod, \
-    FuncName, OptionName, Assign, DictKey, ShellOut, At
+    FuncName, OptionName, Assign, DictKey, ShellOut, At, Let, For
 from peek.parser import process_tokens
 
 _logger = logging.getLogger(__name__)
@@ -212,7 +212,7 @@ class PeekCompleter(Completer):
 
 def find_beginning_token(tokens) -> Tuple[Optional[int], Optional[PeekToken]]:
     for i, t in zip(reversed(range(len(tokens))), tokens[::-1]):
-        if t.ttype in (HttpMethod, FuncName, ShellOut):
+        if t.ttype in (HttpMethod, FuncName, ShellOut, Let, For):
             return i, t
     return None, None
 

--- a/peek/completer.py
+++ b/peek/completer.py
@@ -3,17 +3,17 @@ import logging
 import os
 from typing import Iterable, List, Tuple, Optional
 
-from peek.common import PeekToken
-from peek.completions import PayloadKeyCompletion
-from peek.es_api_spec.spec import ApiSpec
-from peek.lexers import PeekLexer, UrlPathLexer, PathPart, ParamName, Ampersand, QuestionMark, Slash, HttpMethod, \
-    FuncName, OptionName, Assign, DictKey, ShellOut, At, CurlyLeft, BracketLeft, ParenLeft, CurlyRight, BracketRight, \
-    ParenRight
-from peek.parser import process_tokens
 from prompt_toolkit.completion import Completer, CompleteEvent, Completion, WordCompleter, FuzzyCompleter, PathCompleter
 from prompt_toolkit.contrib.completers import SystemCompleter
 from prompt_toolkit.document import Document
 from pygments.token import Error, Name, Literal, String
+
+from peek.common import PeekToken
+from peek.completions import PayloadKeyCompletion
+from peek.es_api_spec.spec import ApiSpec
+from peek.lexers import PeekLexer, UrlPathLexer, PathPart, ParamName, Ampersand, QuestionMark, Slash, HttpMethod, \
+    FuncName, OptionName, Assign, DictKey, ShellOut, At
+from peek.parser import process_tokens
 
 _logger = logging.getLogger(__name__)
 
@@ -23,12 +23,6 @@ _ES_API_CALL_OPTION_COMPLETER = WordCompleter([w + '=' for w in sorted(['conn', 
 
 _PATH_COMPLETER = PathCompleter(expanduser=True)
 _SYSTEM_COMPLETER = SystemCompleter()
-
-_CLOSING_LOOKUP = {
-    CurlyLeft: CurlyRight,
-    BracketLeft: BracketRight,
-    ParenLeft: ParenRight,
-}
 
 
 class PeekCompleter(Completer):

--- a/peek/parser.py
+++ b/peek/parser.py
@@ -69,7 +69,7 @@ class PeekParser:
         self.tokens = []
         self.listeners = listeners or []
 
-    def parse(self, text, payload_only=False, log_level=None):
+    def parse(self, text, payload_only=False, fail_fast_on_error_token=True, log_level=None):
         saved_log_level = _logger.getEffectiveLevel()
         try:
             if log_level is not None:
@@ -80,9 +80,10 @@ class PeekParser:
 
             stack = ('dict',) if payload_only else ('root',)
             self.tokens = process_tokens(self.lexer.get_tokens_unprocessed(self.text, stack=stack))
-            for token in self.tokens:
-                if token.ttype in Token.Error:
-                    raise PeekSyntaxError(self.text, token)
+            if fail_fast_on_error_token:
+                for token in self.tokens:
+                    if token.ttype in Token.Error:
+                        raise PeekSyntaxError(self.text, token)
 
             return self._do_parse_payload() if payload_only else self._do_parse()
         finally:

--- a/tests/test_completer.py
+++ b/tests/test_completer.py
@@ -5,12 +5,12 @@ from unittest.mock import MagicMock
 import pytest
 from prompt_toolkit.completion import CompleteEvent, Completion
 from prompt_toolkit.document import Document
-from pygments.token import Literal
+from pygments.token import Literal, Name
 
 from peek import __file__ as package_root
 from peek.common import PeekToken
 from peek.completer import PeekCompleter, find_beginning_token
-from peek.lexers import HttpMethod, FuncName, BlankLine
+from peek.lexers import HttpMethod, FuncName, BlankLine, Let
 from peek.natives import EXPORTS
 
 package_root = os.path.dirname(package_root)
@@ -70,6 +70,15 @@ def test_find_beginning_token():
         PeekToken(index=0, ttype=FuncName, value='connect'),
         PeekToken(index=7, ttype=BlankLine, value='\n'),
         PeekToken(index=8, ttype=FuncName, value='session')
+    ]
+    i, t = find_beginning_token(tokens)
+    assert i == 2
+
+    tokens = [
+        PeekToken(index=0, ttype=HttpMethod, value='get'),
+        PeekToken(index=4, ttype=Literal, value='abc'),
+        PeekToken(index=8, ttype=Let, value='let'),
+        PeekToken(index=8, ttype=Name, value='foo'),
     ]
     i, t = find_beginning_token(tokens)
     assert i == 2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -283,8 +283,10 @@ def test_parser_events(parser):
 
     parser.parse(text)
     assert len(events) == 4
-    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
-    assert events[3].type is ParserEventType.BEFORE_ES_PAYLOAD
+    assert events[0].type is ParserEventType.BEFORE_ES_METHOD
+    assert events[1].type is ParserEventType.BEFORE_ES_URL
+    assert events[2].type is ParserEventType.BEFORE_ES_OPTION_NAME
+    assert events[3].type is ParserEventType.BEFORE_ES_OPTION_VALUE
 
     events = []
     text = '''GET _search conn=10 headers={
@@ -292,8 +294,9 @@ def test_parser_events(parser):
 '''
     with pytest.raises(PeekSyntaxError):
         parser.parse(text)
-    assert len(events) == 3
-    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
+    assert len(events) == 6
+    assert events[4].type is ParserEventType.BEFORE_ES_OPTION_NAME
+    assert events[5].type is ParserEventType.BEFORE_ES_OPTION_VALUE
 
     events = []
     text = '''GET _search conn=10 headers={
@@ -304,9 +307,24 @@ def test_parser_events(parser):
 '''
     with pytest.raises(PeekSyntaxError):
         parser.parse(text)
+    assert len(events) == 7
+    assert events[6].type is ParserEventType.BEFORE_ES_PAYLOAD_INLINE
+
+    events = []
+    text = '''GET _search
+{"foo": "bar"}
+{"hello'''
+    with pytest.raises(PeekSyntaxError):
+        parser.parse(text)
     assert len(events) == 4
-    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
-    assert events[3].type is ParserEventType.BEFORE_ES_PAYLOAD
+    assert events[3].type is ParserEventType.BEFORE_ES_PAYLOAD_INLINE
+
+    events = []
+    text = '''GET _search
+    @a'''
+    parser.parse(text)
+    assert len(events) == 3
+    assert events[2].type is ParserEventType.BEFORE_ES_PAYLOAD_FILE
 
 
 def test_allow_error_token(parser):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,10 +1,10 @@
 import pytest
 from pygments.token import String, Whitespace, Comment
 
-from peek.ast import EsApiCallNode, ShellOutNode
+from peek.ast import EsApiCallNode, ShellOutNode, EsApiCallInlinePayloadNode, EsApiCallFilePayloadNode
 from peek.errors import PeekSyntaxError
 from peek.lexers import CurlyLeft, CurlyRight
-from peek.parser import PeekParser, process_tokens, PeekToken, ParserListener, ParserEventType
+from peek.parser import PeekParser, process_tokens, PeekToken, ParserEventType
 
 
 @pytest.fixture
@@ -53,7 +53,7 @@ def test_parser_single_es_api_call(parser):
     nodes = parser.parse(text)
     assert len(nodes) == 1
     n = nodes[0]
-    assert isinstance(n, EsApiCallNode)
+    assert isinstance(n, EsApiCallInlinePayloadNode)
     assert n.method == 'GET'
     assert n.path == '/abc'
     assert len(n.dict_nodes) == 0
@@ -121,9 +121,10 @@ def test_parser_file_payload(parser):
     nodes = parser.parse(text)
     assert len(nodes) == 1
     n = nodes[0]
-    assert isinstance(n, EsApiCallNode)
+    assert isinstance(n, EsApiCallFilePayloadNode)
     assert n.method == 'GET'
     assert n.path == '/_abc'
+    assert str(n.file_node) == 'some_file'
 
 
 def test_parser_string_escapes(parser):
@@ -277,13 +278,13 @@ def test_payload_file(parser):
 
 def test_parser_events(parser):
     events = []
-    parser.listeners.append(ParserListener(lambda event: events.append(event)))
+    parser.listeners.append(lambda event: events.append(event))
     text = '''GET _search conn=10'''
 
     parser.parse(text)
     assert len(events) == 4
-    assert events[2].type is ParserEventType.ES_OPTIONS
-    assert events[3].type is ParserEventType.ES_PAYLOAD
+    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
+    assert events[3].type is ParserEventType.BEFORE_ES_PAYLOAD
 
     events = []
     text = '''GET _search conn=10 headers={
@@ -292,7 +293,7 @@ def test_parser_events(parser):
     with pytest.raises(PeekSyntaxError):
         parser.parse(text)
     assert len(events) == 3
-    assert events[2].type is ParserEventType.ES_OPTIONS
+    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
 
     events = []
     text = '''GET _search conn=10 headers={
@@ -304,15 +305,15 @@ def test_parser_events(parser):
     with pytest.raises(PeekSyntaxError):
         parser.parse(text)
     assert len(events) == 4
-    assert events[2].type is ParserEventType.ES_OPTIONS
-    assert events[3].type is ParserEventType.ES_PAYLOAD
+    assert events[2].type is ParserEventType.BEFORE_ES_OPTIONS
+    assert events[3].type is ParserEventType.BEFORE_ES_PAYLOAD
 
 
 def test_allow_error_token(parser):
     text = 'GET _ ()'
 
     events = []
-    parser.listeners.append(ParserListener(lambda event: events.append(event)))
+    parser.listeners.append(lambda event: events.append(event))
 
     with pytest.raises(PeekSyntaxError):
         parser.parse(text)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -306,3 +306,18 @@ def test_parser_events(parser):
     assert len(events) == 4
     assert events[2].type is ParserEventType.ES_OPTIONS
     assert events[3].type is ParserEventType.ES_PAYLOAD
+
+
+def test_allow_error_token(parser):
+    text = 'GET _ ()'
+
+    events = []
+    parser.listeners.append(ParserListener(lambda event: events.append(event)))
+
+    with pytest.raises(PeekSyntaxError):
+        parser.parse(text)
+    assert len(events) == 0
+
+    with pytest.raises(PeekSyntaxError):
+        parser.parse(text, fail_fast_on_error_token=False)
+    assert len(events) > 0


### PR DESCRIPTION
The published events report the parsing progress of high level language constructs while building them. So listener will be able to learn the actual state the parser is in even when the whole parsing fails, e.g. if parsing of API call fails because payload is of invalid format, listener will still be able to learn the parsing is at payload.

Resolves: #129 