### PR TITLE
Upgrade dependencies for version 0.3.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/peek/__init__.py
+++ b/peek/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Yang Wang"""
 __email__ = 'ywangd@gmail.com'
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-prompt-toolkit~=3.0.5
-Pygments>=2.7.4
+prompt-toolkit~=3.0.29
+Pygments~=2.11.2
 configobj~=5.0.6
-elasticsearch>=7.7.0,<8.0.0
-urllib3~=1.26.5
-keyring~=21.2.1
+elasticsearch>=7.17.0,<8.0.0
+urllib3~=1.26.9
+keyring~=23.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,11 @@
-bump2version==0.5.11
-wheel==0.33.6
-watchdog==0.9.0
-flake8==3.7.8
-tox==3.14.0
-coverage==4.5.4
-Sphinx==1.8.5
-twine==1.14.0
+bump2version==1.0.1
+wheel==0.37.1
+watchdog==2.1.7
+flake8==4.0.1
+tox==3.24.5
+coverage==6.3.2
+Sphinx==4.5.0
+twine==4.0.0
 
-pytest==4.6.5
-pytest-runner==5.1
+pytest==7.1.1
+pytest-runner==6.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.3.0
 commit = True
 tag = True
 
@@ -23,5 +23,4 @@ max-line-length = 140
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
-
+addopts = --ignore=setup.py

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -113,7 +113,7 @@ def test_connect_will_prefer_cloud_id():
     mock_app = MagicMock(name='PeekApp')
     mock_app.config.as_bool = MagicMock(return_value=False)
 
-    mock_es = MagicMock
+    mock_es = MagicMock()
     MockEs = MagicMock(return_value=mock_es)
 
     with patch('peek.connection.Elasticsearch', MockEs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py36, py37, py38, py39, flake8
+envlist = py38, py39, py310, flake8
 
 [travis]
 python =
+    3.10: py310
     3.9: py39
     3.8: py38
-    3.7: py37
-    3.6: py36
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
* Drop support for python 3.6 and 3.7 and add support for 3.10
* elasticsearch-py to 7.17 and fix relevant usages accordingly
* All other dependencies are upgraded to their lastet version.