### PR TITLE
Setup Trusted Publishing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 
@@ -18,7 +21,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release to PyPI
+
+on:
+  push:
+    branches:
+      - "main"
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: github.repository_owner == 'ywangd'
+    name: Build dists
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+            persist-credentials: false
+            fetch-depth: 0 # Needed to fetch the version from git
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: python -m pip install build
+      - name: Build dists
+        run: python -m build
+      - name: Upload dists
+        uses: actions/upload-artifact@v6
+        with:
+          name: "dist"
+          path: "dist/"
+          if-no-files-found: error
+          retention-days: 5
+
+  pypi-publish:
+    name: Upload release to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write  # Needed for trusted publishing to PyPI
+
+    steps:
+      - name: Download dists
+        uses: actions/download-artifact@v6
+        with:
+          name: "dist"
+          path: "dist/"
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.13.0
+
+  test-pypi-publish:
+    name: "Upload release to Test PyPI"
+    needs: ["build"]
+    permissions:
+      id-token: write # Needed for trusted publishing to Test PyPI.
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "testpypi"
+
+    steps:
+    - name: "Download dists"
+      uses: actions/download-artifact@v6
+      with:
+        artifact-ids: ${{ needs.build.outputs.artifact-id }}
+        path: "dist/"
+    - name: "Publish dists to Test PyPI"
+      uses: pypa/gh-action-pypi-publish@v1.13.0
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/peek/__init__.py
+++ b/peek/__init__.py
@@ -1,5 +1,13 @@
 """Top-level package for peek."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 __author__ = """Yang Wang"""
 __email__ = 'ywangd@gmail.com'
-__version__ = '0.4.0'
+
+
+try:
+    __version__ = version("es-peek")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme"]
+requires = ["hatchling", "hatch-fancy-pypi-readme", "hatch-vcs~=0.5.0", "setuptools-scm~=9.2.2"]
 build-backend = "hatchling.build"
 
 [project]
@@ -64,7 +64,9 @@ peek = "peek.cli:main"
 Homepage = "https://github.com/ywangd/peek"
 
 [tool.hatch.version]
-path = "peek/__init__.py"
+source = "vcs"
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
With [Trusted Publishing](https://docs.pypi.org/trusted-publishers/), we can perform releases directly from GitHub Actions. The way it works:

* You push the 1.0.0 tag to GitHub, which triggers the release.yml workflow
* This triggers the `build` step, which generates a source distribution (ending in .tgz) and a wheel (ending in .whl)
* Next, the pypi-publish step runs, which triggers the `release` GitHub environment, requiring you to approve the workflow
* Then, the build distribution files are downloaded from the previous step
* GitHub sends an OIDC token to PyPI, which sends back a short-lived API token, which is used to upload the package

An added complication here is that we're also publishing to Test PyPI on every commit. This is the only way, in my experience, to avoid problems with each new release, which defeats the purpose of automation. This brings a new complication, however: releases on PyPI are immutable, so we can't upload 0.5.0 repeatedly. This is why we use hatch-vcs, which generates a dynamic version based on the latest tag and the number of commits since that tag. That's how I ended up publishing https://test.pypi.org/project/es-peek/0.4.1.dev11/.

Checklist before merging:

- [x] Create two new GitHub environments
  - [x] The first one, called `release`, should be allowed to run on all tags, require a review from ywangd, and not allow administration by pass.
  - [x] The second one, called `testpypi`, should be allowed to run on the main branch, without requiring any review.
- [x] Create an account on Test PyPI, so that I can give you ownership of es-peek there
- [x] Setup Trusted Publishing on PyPI
  - Owner: ywangd
  - Repository name: peek
  - Workflow name: release.yml
  - Environment name: testpypi